### PR TITLE
Always copy CNAME to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "deploy": "gatsby build && gh-pages -d public",
+    "deploy": "cp CNAME public/ && gatsby build && gh-pages -d public",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Workaround for making sure that the CNAME is not overridden on deploy